### PR TITLE
Stop changing negative new_tested, new_deceased, and new_confirmed to…

### DIFF
--- a/src/widgets/confirmed-cases-per-100k.tpl.html
+++ b/src/widgets/confirmed-cases-per-100k.tpl.html
@@ -29,7 +29,7 @@
             }
 
             // Convert the relevant rows to numbers
-            locationData = mapToNumeric(locationData, columns, true);
+            locationData = mapToNumeric(locationData, columns, false);
 
             // Get rid of irrelevant data according to settings
             const indices = new Set(filterDataIndices(locationData, rollingWindowSize));

--- a/src/widgets/confirmed-cases.tpl.html
+++ b/src/widgets/confirmed-cases.tpl.html
@@ -24,7 +24,7 @@
             }
 
             // Convert the relevant rows to numbers
-            locationData = mapToNumeric(locationData, columns, positive = true);
+            locationData = mapToNumeric(locationData, columns, positive = false);
 
             // Get rid of irrelevant data according to settings
             const indices = new Set(filterDataIndices(locationData));

--- a/src/widgets/deceased-persons.tpl.html
+++ b/src/widgets/deceased-persons.tpl.html
@@ -29,7 +29,7 @@
             }
 
             // Convert the relevant rows to numbers
-            locationData = mapToNumeric(locationData, columns, true);
+            locationData = mapToNumeric(locationData, columns, false);
 
             // Get rid of irrelevant data according to settings
             const indices = new Set(filterDataIndices(locationData, rollingWindowSize * 2));

--- a/src/widgets/tests-performed.tpl.html
+++ b/src/widgets/tests-performed.tpl.html
@@ -29,8 +29,7 @@
             }
 
             // Convert the relevant rows to numbers
-            locationData = mapToNumeric(locationData, columns, positive = true);
-
+            locationData = mapToNumeric(locationData, columns, positive = false);
             // Get rid of irrelevant data according to settings
             const indices = new Set(filterDataIndices(locationData, rollingWindowSize, ['new_tested']));
             locationData = locationData
@@ -39,9 +38,9 @@
 
             // Use a moving average for the positivity rate to avoid spikes
             const data = locationData.rolling(rollingWindowSize).map(rows => {
-                const rollingSumNumerator = Math.max(0, rows.map(x => x.new_confirmed).sum());
-                const rollingSumDenominator = Math.max(1, rows.map(x => x.new_tested).sum());
-                const positivityRate = Math.min(1, rollingSumNumerator / rollingSumDenominator);
+                const rollingSumNumerator = rows.map(x => x.new_confirmed).sum();
+                const rollingSumDenominator = rows.map(x => x.new_tested).sum();
+                const positivityRate = rollingSumNumerator / rollingSumDenominator;
 
                 return {
                     ['Date']: rows.slice(-1)[0].date,


### PR DESCRIPTION
… zero since they can appear in unrolling of inaccurate moving average data and should be taken into account in computing rolling averages and ratios.

New:
![cases_US_CA_06059_new](https://user-images.githubusercontent.com/6868679/115618100-13c75200-a2a7-11eb-8b8c-9d28ef9d3007.png)
Old:
![cases_US_CA_06059_old](https://user-images.githubusercontent.com/6868679/115618103-15911580-a2a7-11eb-9077-a601e6fc64fe.png)
New:
![positivity_US_CA_06059_new](https://user-images.githubusercontent.com/6868679/115618110-175ad900-a2a7-11eb-8f32-afc359d3cd3c.png)
Old:
![positivity_US_CA_06059_old](https://user-images.githubusercontent.com/6868679/115618116-17f36f80-a2a7-11eb-9bab-d50eb673089c.png)
New:
![mortality_US_NY_36087_new](https://user-images.githubusercontent.com/6868679/115618106-1629ac00-a2a7-11eb-896a-762ee438b73a.png)
Old:
![mortality_US_NY_36087_old](https://user-images.githubusercontent.com/6868679/115618108-16c24280-a2a7-11eb-9325-ada1f3d0c00d.png)




